### PR TITLE
Add ability to specify additional log data to honeytail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/cloudsqltail ./cmd
 FROM alpine:3.10
 
 RUN apk add --update ca-certificates
+RUN apk add bash
 # honeytail was compiled against libc, not musl, but they're compatible.
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
@@ -25,4 +26,4 @@ COPY run.sh .
 RUN wget -q -O honeytail https://honeycomb.io/download/honeytail/linux/1.762 \
     && echo '00e24441316c7ae24665b1aaea4cbb77e2ee52c83397bf67d70f3ffe14a1e341  honeytail' | sha256sum -c \
     && chmod 755 /app/honeytail
-CMD ["ash", "/app/run.sh"]
+CMD ["bash", "/app/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,16 @@ if ! [[ -z "${DEBUG:-}" ]]; then
     HTDEBUG="--debug --debug_stdout"
 fi
 
+if ! [[ -z "${ADD_PARAMS:-}" ]]; then
+    ADD_PARAMS_ARR=($(echo "${ADD_PARAMS}"));
+    ADDITIONAL_FLAGS=""
+    for (( i = 1 ; i < ${#ADD_PARAMS_ARR[@]} ; i+=2 )); do
+        FIELD_NAME="${ADD_PARAMS_ARR[$i]}"
+        FIELD_VALUE="${ADD_PARAMS_ARR[$((i + 1))]}"
+        ADDITIONAL_FLAGS+="--add_field \"${FIELD_NAME}\"=\"${FIELD_VALUE}\" "
+    done
+fi
+
 # In-cluster gcloud auth
 if [[ "${GOOGLE_APPLICATION_CREDENTIALS_JSON:-}" != "" ]]; then
     echo $GOOGLE_APPLICATION_CREDENTIALS_JSON > service-account.key
@@ -19,4 +29,5 @@ fi
     --dataset="${DATASET:-postgres}" \
     --parser=postgresql \
     --postgresql.log_line_prefix='[%t]: [%p]: [%l-1] db=%d,user=%u' \
+    "${ADDITIONAL_FLAGS:-}" \
     -f -

--- a/run.sh
+++ b/run.sh
@@ -7,13 +7,18 @@ if ! [[ -z "${DEBUG:-}" ]]; then
     HTDEBUG="--debug --debug_stdout"
 fi
 
+ADDITIONAL_FLAGS=()
 if ! [[ -z "${ADD_PARAMS:-}" ]]; then
-    ADD_PARAMS_ARR=($(echo "${ADD_PARAMS}"));
-    ADDITIONAL_FLAGS=""
-    for (( i = 1 ; i < ${#ADD_PARAMS_ARR[@]} ; i+=2 )); do
+    ADD_PARAMS_ARR=()
+    while IFS='' read val; do
+        ADD_PARAMS_ARR+=("$val")
+    done < <(xargs -n1 <<<"$ADD_PARAMS")
+
+    for (( i = 0 ; i < ${#ADD_PARAMS_ARR[@]} ; i+=2 )); do
         FIELD_NAME="${ADD_PARAMS_ARR[$i]}"
         FIELD_VALUE="${ADD_PARAMS_ARR[$((i + 1))]}"
-        ADDITIONAL_FLAGS+="--add_field \"${FIELD_NAME}\"=\"${FIELD_VALUE}\" "
+        ADDITIONAL_FLAGS+=("--add_field")
+        ADDITIONAL_FLAGS+=("'${FIELD_NAME}'='${FIELD_VALUE}'")
     done
 fi
 
@@ -29,5 +34,5 @@ fi
     --dataset="${DATASET:-postgres}" \
     --parser=postgresql \
     --postgresql.log_line_prefix='[%t]: [%p]: [%l-1] db=%d,user=%u' \
-    "${ADDITIONAL_FLAGS:-}" \
+    "${ADDITIONAL_FLAGS[@]}" \
     -f -

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,12 @@ if ! [[ -z "${ADD_PARAMS:-}" ]]; then
     while IFS='' read val; do
         ADD_PARAMS_ARR+=("$val")
     done < <(xargs -n1 <<<"$ADD_PARAMS")
+    if (( ${#ADD_PARAMS_ARR[@]} % 2 == 1 )); then
+        echo "Invalid number of additional parameters. Must be divisble by two."
+        echo "Please ensure you escape params with spaces with single or double"
+        echo "quotes and not with backslashes before the spaces."
+        exit 1
+    fi
 
     for (( i = 0 ; i < ${#ADD_PARAMS_ARR[@]} ; i+=2 )); do
         FIELD_NAME="${ADD_PARAMS_ARR[$i]}"


### PR DESCRIPTION
**What**
Adding the ability to pass additional logging fields to log entries in honeytail.

**Why**
When data from multiple servers/regions is logged to the same dataset in honeycomb, there's no way to distinguish between them. It's helpful to add additional detail to the logs in order to determine which particular server is having performance issues.

**How**
Convert list of `ADD_PARAMS` env variable into `--add_field A=B` params to honeytail. 